### PR TITLE
Enforce LF line endings for output file

### DIFF
--- a/assdiff3.py
+++ b/assdiff3.py
@@ -446,8 +446,8 @@ def main():
     if args.output is None:
         sys.stdout.buffer.write(output.getvalue().encode('utf-8-sig'))
     else:
-        with open(args.output, 'w', encoding='utf-8-sig') as f:
-            f.write(output.getvalue())
+        with open(args.output, 'wb') as f:
+            f.write(output.getvalue().encode('utf-8-sig'))
 
     if dialogue_conflict or style_conflict:
         sys.exit(1)


### PR DESCRIPTION
When writing to files opened in text mode, Python will automatically choose the line endings depending on the operating system. When assdiff3 is used as a merge driver for git, it will be invoked on git's internal files, which use LF line endings unless configured otherwise. Before this PR, assdiff3 would output CRLF files, which would merge properly but mark every line of the file as changed in the merge commit.

By opening the file in binary mode, one can enforce LF endings. Thus, this will fix this issue as long as git is not configured to use CRLF line endings internally for .ass files. Also fixing the issue in that case would require detecting the line ending types of the input files, which is a larger modification of the code.